### PR TITLE
Version 3

### DIFF
--- a/Resources/config/collectors.yml
+++ b/Resources/config/collectors.yml
@@ -24,7 +24,7 @@ services:
     liuggio_stats_d_client.collector.user:
         class: %liuggio_stats_d_client.collector.user.class%
         calls:
-            - ['setSecurityContext', ['@security.context']]
+            - ['setSecurityContext', ['@security.authorization_checker']]
             - ['setOnlyOnMasterResponse', [true]]
         tags:
             - { name: stats_d_collector}

--- a/StatsCollector/ExceptionStatsCollector.php
+++ b/StatsCollector/ExceptionStatsCollector.php
@@ -23,7 +23,7 @@ class ExceptionStatsCollector extends StatsCollector
             return true;
         }
 
-        $key = sprintf('%s.exception.%s', $this->getStatsDataKey(), $exception->getCode());
+        $key = sprintf('%s.%s', $this->getStatsDataKey(), $exception->getCode());
         $statData = $this->getStatsdDataFactory()->increment($key);
         $this->addStatsData($statData);
 

--- a/StatsCollector/StatsCollector.php
+++ b/StatsCollector/StatsCollector.php
@@ -119,7 +119,7 @@ abstract class StatsCollector implements StatsCollectorInterface
     }
 
     /**
-     * Extract the first word, its maximum lenght is limited to $maxLenght chars.
+     * Extract the first word, its maximum length is limited to $maxLenght chars.
      *
      * @param  string $string
      *

--- a/StatsCollector/UserStatsCollector.php
+++ b/StatsCollector/UserStatsCollector.php
@@ -5,7 +5,7 @@ namespace Liuggio\StatsDClientBundle\StatsCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class UserStatsCollector extends StatsCollector
 {
@@ -40,7 +40,7 @@ class UserStatsCollector extends StatsCollector
         return true;
     }
 
-    public function setSecurityContext(SecurityContextInterface $security_context)
+    public function setSecurityContext(AuthorizationCheckerInterface $security_context)
     {
         $this->security_context = $security_context;
     }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.2",
         "liuggio/statsd-php-client": "~1.0.14",
-        "symfony/framework-bundle": ">2.0"
+        "symfony/framework-bundle": ">=3.0"
     },
     "require-dev": {
         "doctrine/dbal": ">=2.2.0",


### PR DESCRIPTION
This result a broken changes because of minimum stability of symfony 3, but this will solve the issues undefined security_context that doesn't exist anymore on Symfony3
