### PR TITLE
Fix symfony 4.2 deprecation notice #74

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,7 +25,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('liuggio_stats_d_client');
-        $rootNode    = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('liuggio_stats_d_client');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('liuggio_stats_d_client');
 
         $rootNode
           ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,8 +24,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('liuggio_stats_d_client');
+        $treeBuilder = new TreeBuilder('liuggio_stats_d_client');
+        $rootNode    = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('liuggio_stats_d_client');
 
         $rootNode
           ->children()


### PR DESCRIPTION
This should fix the symfony 4.2 deprecation notice while still being backward compatible with previous versions. 