### PR TITLE
Remove classname parameters

### DIFF
--- a/DependencyInjection/LiuggioStatsDClientExtension.php
+++ b/DependencyInjection/LiuggioStatsDClientExtension.php
@@ -24,9 +24,6 @@ class LiuggioStatsDClientExtension extends Extension
         $configuration = new Configuration($container->getParameter('kernel.debug'));
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter($this->getAlias().'.sender.class', $config['connection']['class']);
-        $container->setParameter($this->getAlias().'.sender.debug_class', $config['connection']['debug_class']);
-
         foreach ($config['connection'] as $k => $v) {
             $container->setParameter($this->getAlias().'.connection.'.$k, $v);
         }
@@ -41,7 +38,7 @@ class LiuggioStatsDClientExtension extends Extension
 
             if (\count($config['collectors'])) {
                 // Define the Listener
-                $definition = new Definition('%liuggio_stats_d_client.collector.listener.class%',
+                $definition = new Definition('Liuggio\StatsDClientBundle\Listener\StatsDCollectorListener',
                     [new Reference('liuggio_stats_d_client.collector.service')]
                 );
                 $definition->addTag('kernel.event_subscriber');
@@ -52,11 +49,18 @@ class LiuggioStatsDClientExtension extends Extension
         if (!empty($config['monolog']) && $config['monolog']['enable']) {
             $this->loadMonologHandler($config, $container);
         }
+
         // set the debug sender
         if ($config['connection']['debug']) {
-            $senderService = new Definition('%liuggio_stats_d_client.sender.debug_class%');
+            $senderService = new Definition($config['connection']['debug_class'], []);
             $container->setDefinition('liuggio_stats_d_client.sender.service', $senderService);
-            $senderService->setArguments([]);
+        } else {
+            $senderService = new Definition($config['connection']['class'], [
+                $config['connection']['host'],
+                $config['connection']['port'],
+                $config['connection']['protocol'],
+            ]);
+            $container->setDefinition('liuggio_stats_d_client.sender.service', $senderService);
         }
     }
 
@@ -82,7 +86,7 @@ class LiuggioStatsDClientExtension extends Extension
         );
         $container->setDefinition('monolog.formatter.statsd', $def2);
 
-        $def = new Definition($container->getParameter('liuggio_stats_d_client.monolog_handler.class'), [
+        $def = new Definition('Liuggio\StatsdClient\Monolog\Handler\StatsDHandler', [
             new Reference('liuggio_stats_d_client.service'),
             new Reference('liuggio_stats_d_client.factory'),
             $config['monolog']['prefix'],

--- a/Resources/config/collectors.yml
+++ b/Resources/config/collectors.yml
@@ -1,53 +1,45 @@
-parameters:
-    liuggio_stats_d_client.collector.visitor.class: Liuggio\StatsDClientBundle\StatsCollector\VisitorStatsCollector
-    liuggio_stats_d_client.collector.memory.class: Liuggio\StatsDClientBundle\StatsCollector\MemoryStatsCollector
-    liuggio_stats_d_client.collector.user.class: Liuggio\StatsDClientBundle\StatsCollector\UserStatsCollector
-    liuggio_stats_d_client.collector.exception.class: Liuggio\StatsDClientBundle\StatsCollector\ExceptionStatsCollector
-    liuggio_stats_d_client.collector.time.class: Liuggio\StatsDClientBundle\StatsCollector\TimeStatsCollector
-
-
 services:
     liuggio_stats_d_client.collector.visitor:
-        class: '%liuggio_stats_d_client.collector.visitor.class%'
+        class: 'Liuggio\StatsDClientBundle\StatsCollector\VisitorStatsCollector'
         calls:
             - ['setOnlyOnMasterResponse', [true]]
         tags:
-            - { name: stats_d_collector}
+            - { name: stats_d_collector }
 
     liuggio_stats_d_client.collector.memory:
-        class: '%liuggio_stats_d_client.collector.memory.class%'
+        class: 'Liuggio\StatsDClientBundle\StatsCollector\MemoryStatsCollector'
         calls:
             - ['setOnlyOnMasterResponse', [true]]
         tags:
-            - { name: stats_d_collector}
+            - { name: stats_d_collector }
 
     liuggio_stats_d_client.collector.user:
-        class: '%liuggio_stats_d_client.collector.user.class%'
+        class: 'Liuggio\StatsDClientBundle\StatsCollector\UserStatsCollector'
         calls:
             - ['setSecurityContext', ['@security.authorization_checker']]
             - ['setOnlyOnMasterResponse', [true]]
         tags:
-            - { name: stats_d_collector}
+            - { name: stats_d_collector }
 
     liuggio_stats_d_client.collector.exception:
-        class: '%liuggio_stats_d_client.collector.exception.class%'
+        class: 'Liuggio\StatsDClientBundle\StatsCollector\ExceptionStatsCollector'
         calls:
             - ['setOnlyOnMasterResponse', [false]]
         tags:
-            - { name: stats_d_collector}
+            - { name: stats_d_collector }
 
     liuggio_stats_d_client.collector.time:
-        class: '%liuggio_stats_d_client.collector.time.class%'
+        class: 'Liuggio\StatsDClientBundle\StatsCollector\TimeStatsCollector'
         calls:
             - ['setOnlyOnMasterResponse', [true]]
         tags:
-            - { name: stats_d_collector}
+            - { name: stats_d_collector }
 
-#special connector dbal is also a sqllogger
+    #special connector dbal is also a sqllogger
     liuggio_stats_d_client.collector.dbal:
-        class: '%liuggio_stats_d_client.collector.dbal.class%'
+        class: 'Liuggio\StatsDClientBundle\StatsCollector\DbalStatsCollector'
         arguments: ['query']
         calls:
             - ['setOnlyOnMasterResponse', [true]]
         tags:
-            - { name: stats_d_collector}
+            - { name: stats_d_collector }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,39 +1,29 @@
-parameters:
-    liuggio_stats_d_client.service.class: Liuggio\StatsdClient\StatsdClient
-    liuggio_stats_d_client.entity.class: Liuggio\StatsdClient\Entity\StatsdData
-    liuggio_stats_d_client.factory.class: Liuggio\StatsdClient\Factory\StatsdDataFactory
-    liuggio_stats_d_client.sender.debug.class: Liuggio\StatsdClient\Sender\EchoSender
-    liuggio_stats_d_client.collector.service.class: Liuggio\StatsDClientBundle\Service\StatsDCollectorService
-    liuggio_stats_d_client.collector.listener.class: Liuggio\StatsDClientBundle\Listener\StatsDCollectorListener
-    liuggio_stats_d_client.collector.dbal.class: Liuggio\StatsDClientBundle\StatsCollector\DbalStatsCollector
-    liuggio_stats_d.sender.class: Liuggio\StatsdClient\Service\StatsdService
-
-# monolog handler
-    liuggio_stats_d_client.monolog_handler.class: Liuggio\StatsdClient\Monolog\Handler\StatsDHandler
-
 services:
-# statsd-php-client
+    # statsd-php-client
     liuggio_stats_d_client.factory:
-        class: '%liuggio_stats_d_client.factory.class%'
-        arguments: ['%liuggio_stats_d_client.entity.class%']
-
-    liuggio_stats_d_client.sender.service:
-        class: '%liuggio_stats_d_client.sender.class%'
-        arguments: ['%liuggio_stats_d_client.connection.host%', '%liuggio_stats_d_client.connection.port%', '%liuggio_stats_d_client.connection.protocol%']
+        class: 'Liuggio\StatsdClient\Factory\StatsdDataFactory'
+        arguments:
+            - 'Liuggio\StatsdClient\Entity\StatsdData'
 
     liuggio_stats_d_client.service:
-        class: '%liuggio_stats_d_client.service.class%'
-        arguments: ['@liuggio_stats_d_client.sender.service', '%liuggio_stats_d_client.connection.reduce_packet%', '%liuggio_stats_d_client.connection.fail_silently%']
+        class: 'Liuggio\StatsdClient\StatsdClient'
+        arguments:
+            - '@liuggio_stats_d_client.sender.service'
+            - '%liuggio_stats_d_client.connection.reduce_packet%'
+            - '%liuggio_stats_d_client.connection.fail_silently%'
 
-# collector service
+    # collector service
     liuggio_stats_d_client.collector.service:
-        class: '%liuggio_stats_d_client.collector.service.class%'
-        arguments: ['@liuggio_stats_d_client.service']
+        class: 'Liuggio\StatsDClientBundle\Service\StatsDCollectorService'
+        arguments:
+            - '@liuggio_stats_d_client.service'
 
-# simplified service
+    # simplified service
     liuggio_stats_d.service:
-        class: '%liuggio_stats_d.sender.class%'
-        arguments: ['@liuggio_stats_d_client.service', '@liuggio_stats_d_client.factory']
+        class: 'Liuggio\StatsdClient\Service\StatsdService'
+        arguments:
+            - '@liuggio_stats_d_client.service'
+            - '@liuggio_stats_d_client.factory'
 
     statsd:
-         alias: liuggio_stats_d.service
+        alias: liuggio_stats_d.service


### PR DESCRIPTION
This is an attempt to fix #68 
Unit tests are ok but I can't test it functionally right now, I hope you don't mind.

## About the dbal collector
I couldn't find the parameter `liuggio_stats_d_client.collector.dbal.class` anywhere so I guessed it (I'm not sur how it worked without that)

Happy hacktoberfest everyone :tada: 